### PR TITLE
Remove double connection to mongodb

### DIFF
--- a/tests/test_mongoengine.py
+++ b/tests/test_mongoengine.py
@@ -64,9 +64,6 @@ class MongoEngineTestCase(unittest.TestCase):
     def tearDownClass(cls):
         cls.db.drop_database(cls.db_name)
 
-    def setUp(self):
-        mongoengine.connect('factory_boy_test')
-
     def test_build(self):
         std = PersonFactory.build()
         self.assertEqual('name0', std.name)


### PR DESCRIPTION
Fixes travis error:

```
Traceback (most recent call last):
  File "/home/travis/build/FactoryBoy/factory_boy/tests/test_mongoengine.py", line 68, in setUp
    mongoengine.connect('factory_boy_test')
  File "/home/travis/build/FactoryBoy/factory_boy/.tox/py27-django111-alchemy-mongoengine/lib/python2.7/site-packages/mongoengine/connection.py", line 363, in connect
    'A different connection with alias `%s` was already registered. Use disconnect() first' % alias)
MongoEngineConnectionError: A different connection with alias `default` was already registered. Use disconnect() first
```